### PR TITLE
Feat: Reader schemas default to null for optionals

### DIFF
--- a/theta/src/Theta/Target/Avro/Types.hs
+++ b/theta/src/Theta/Target/Avro/Types.hs
@@ -294,8 +294,11 @@ record recordName avroVersion doc Fields { fields } = do
         , Avro.fldDoc     = getText <$> fieldDoc
         , Avro.fldOrder   = Nothing
         , Avro.fldType    = type_
-        , Avro.fldDefault = Nothing
+        , Avro.fldDefault = defaultValue fieldType type_
         }
+
+    defaultValue Type{baseType = Optional' _} Avro.Union{options} = Just (Avro.DUnion options Avro.Null Avro.DNull)
+    defaultValue _ _ = Nothing
 
     force xs = liftRnf (`seq` ()) xs `seq` xs
 {-# SPECIALIZE record :: Name -> Version -> Maybe Doc -> Fields Type -> StateT (Set Name) (Either Theta.Error) Schema #-}

--- a/theta/src/Theta/Versions.hs
+++ b/theta/src/Theta/Versions.hs
@@ -79,7 +79,7 @@ avro = Range { name = "avro-version", lower = "1.0.0", upper = "1.2.0" }
 
 -- | Which version of the Theta package this is.
 packageVersion :: Cabal.Version
-packageVersion = Cabal.makeVersion [1, 0, 0, 2]
+packageVersion = Cabal.makeVersion [1, 0, 1, 1]
 
 -- | Which version of the Theta package this is as 'Text'.
 packageVersion' :: Text

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           theta
-version:        1.0.0.2
+version:        1.0.1.1
 synopsis:       Share algebraic data types across different languages with Avro.
 description:    Use algebraic data types to define data formats that work across different languages. Theta lets you use a single set of types to generate Avro schemas as well as types that serialize and deserialize to those schemas in Python, Haskell and Rust.
 license:        Apache-2.0


### PR DESCRIPTION
Some related discussions in: <https://github.com/target/theta-idl/issues/70>

Theta is not generating a `default` specification in record fields that
are specified as optional.

This meant that readers (using the haskell `avro` library) could not
decode data, failing with a message like

```
AvroDecodingException "No default found for deconflicted field [someOptionalField]"
```

The specification says:

> Default values for union fields correspond to the first schema in the union.

From: <https://avro.apache.org/docs/current/spec.html#Unions>

It is unclear whether this part of the specification is meant to be
implemented or not.

Now `theta` will take an approach where Optional types will carry
`default` specification that defaults the value to null in the reader
when it's missing in the writer schema.