### PR TITLE
Fix case of deconflicted reads for optional types

### DIFF
--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           theta
-version:        1.0.1.1
+version:        1.0.1.2
 synopsis:       Share algebraic data types across different languages with Avro.
 description:    Use algebraic data types to define data formats that work across different languages. Theta lets you use a single set of types to generate Avro schemas as well as types that serialize and deserialize to those schemas in Python, Haskell and Rust.
 license:        Apache-2.0


### PR DESCRIPTION
This was missing from https://github.com/daiseeai/theta-idl/pull/3 where we successfully managed to deconflict optional types in reader schemas. However that only got us one step of the way and missed a corner case, which is addressed here.